### PR TITLE
Fix mypy type errors

### DIFF
--- a/custom_components/ctek/sensor.py
+++ b/custom_components/ctek/sensor.py
@@ -167,6 +167,7 @@ class CtekSensor(CtekEntity, SensorEntity):
     """ctek Sensor class."""
 
     _attr_native_value: ChargeStateEnum | str | int | float | datetime | None = None
+    entity_description: SensorEntityDescription
 
     def __init__(
         self,

--- a/custom_components/ctek/switch.py
+++ b/custom_components/ctek/switch.py
@@ -77,6 +77,7 @@ class CtekSwitch(CtekEntity, SwitchEntity):
 
     _attr_is_on: bool | None
     _configs: bool = False
+    entity_description: SwitchEntityDescription
 
     def __init__(
         self,

--- a/custom_components/ctek/ws.py
+++ b/custom_components/ctek/ws.py
@@ -75,7 +75,7 @@ class WebSocketClient:
         async with self.session.ws_connect(
             self.url,
             heartbeat=30,  # Send ping every 30 seconds
-            timeout=60,  # Connection timeout
+            timeout=aiohttp.ClientWSTimeout(ws_receive=60, ws_close=60),
             headers=headers,
         ) as websocket:
             self.websocket = websocket


### PR DESCRIPTION
## Summary
- `ws.py`: Replace bare `int` timeout with `aiohttp.ClientWSTimeout(ws_receive=60, ws_close=60)`
- `sensor.py`: Add `entity_description: SensorEntityDescription` class attribute to narrow type from `EntityDescription | None`
- `switch.py`: Add `entity_description: SwitchEntityDescription` class attribute to narrow type from `EntityDescription | None`

All pre-existing mypy errors are now resolved — `pre-commit run mypy --all-files` passes cleanly.

## Test plan
- [ ] `pre-commit run mypy --all-files` passes
- [ ] `pytest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)